### PR TITLE
Update deployments to use apps/v1

### DIFF
--- a/yaml/kubernetes/connector-dep.yml
+++ b/yaml/kubernetes/connector-dep.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vcenter-connector
@@ -8,6 +8,10 @@ metadata:
     component: vcenter-connector
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: vcenter
+      component: vcenter-connector
   template:
     metadata:
       labels:

--- a/yaml/kubernetes/vcsim-server-dep.yml
+++ b/yaml/kubernetes/vcsim-server-dep.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vcsim-server
@@ -8,6 +8,10 @@ metadata:
     component: vcsim-server
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: vcsim
+      component: vcsim-server
   template:
     metadata:
       labels:


### PR DESCRIPTION
Updating the deployments to use apps/v1 instead of
extensions/v1beta1 as kubernetes 1.16 is depricating
extensions/v1beta1 and apps/v1 is becoming the standart
one

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Kubernetes is deprecating the extensions type and `apps/v1` is mandatory for kubernetes 1.16+

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] My issue has received approval from the maintainers or lead with the `design/approved` label (I believe so)
Closes #29 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Applied the connector components on Kubernetes 16.2
```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.0", GitCommit:"e8462b5b5dc2584fdcd18e6bcfe9f1e4d970a529", GitTreeState:"clean", BuildDate:"2019-06-19T16:40:16Z", GoVersion:"go1.12.5", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.2", GitCommit:"c97fe5036ef3df2967d086711e6c0c405941e14b", GitTreeState:"clean", BuildDate:"2019-10-15T19:09:08Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
```
```
$ kubectl get pods -n openfaas
NAME                                 READY   STATUS    RESTARTS   AGE
alertmanager-8447d569c8-6jcwr        1/1     Running   1          15d
basic-auth-plugin-76899dc95-h7d2d    1/1     Running   1          15d
faas-idler-86b55ffcbf-c8j44          1/1     Running   5          15d
gateway-598497c4fb-zn4v4             2/2     Running   4          15d
kafka-broker-57b8766694-nlmz6        1/1     Running   3          15d
kafka-connector-5ccc6f7fc8-wfmf8     1/1     Running   9          15d
nats-6b6d549b56-dcksn                1/1     Running   1          15d
prometheus-7f694ddc48-8544j          1/1     Running   1          15d
queue-worker-554946dc65-pmbnp        1/1     Running   3          15d
vcenter-connector-5648c9f8c4-9pb4v   1/1     Running   0          9m31s
vcsim-server-b767bc6b8-zz7g7         1/1     Running   0          11m
zookeeper-8794dcbdf-tdwwd            1/1     Running   1          15d
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Compatibility support

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
